### PR TITLE
Fix issue during inclusion of resource

### DIFF
--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -12,7 +12,7 @@ services:
             tags: ['doctrine.encryptor']
 
     Shapecode\NYADoctrineEncryptBundle\Encryption\:
-        resource: '../../Encryption/Encryption/*'
+        resource: '../../Encryption/*'
 
     Shapecode\NYADoctrineEncryptBundle\Encryption\Encryptor\:
         resource: '../../Encryption/Encryptor/*'


### PR DESCRIPTION
>   The file "../../Encryption/Encryption" does not exist (in: /Users/....../vendor/shapecode/nya-doctrine-encrypt-bundle/src/DependencyInjection/../Resources/config).

Fix https://github.com/shapecode/nya-doctrine-encrypt-bundle/issues/2